### PR TITLE
Support keepOneOverlayVisible feature in markers

### DIFF
--- a/src/directives/marker.js
+++ b/src/directives/marker.js
@@ -8,7 +8,8 @@ angular.module('openlayers-directive').directive('olMarker', function($log, $q, 
             coord: [],
             show: true,
             showOnMouseOver: false,
-            showOnMouseClick: false
+            showOnMouseClick: false,
+            keepOneOverlayVisible: false
         };
     };
 
@@ -202,6 +203,54 @@ angular.module('openlayers-directive').directive('olMarker', function($log, $q, 
                         }
                     }
 
+                    function showAtLeastOneOverlay(evt) {
+                        if (properties.label.show) {
+                            return;
+                        }
+                        var found = false;
+                        var pixel = map.getEventPixel(evt);
+                        var feature = map.forEachFeatureAtPixel(pixel, function (feature) {
+                            return feature;
+                        });
+
+                        var actionTaken = false;
+                        if (feature === marker) {
+                            actionTaken = true;
+                            found = true;
+                            if (!isDefined(label)) {
+                                if (data.projection === 'pixel') {
+                                    pos = data.coord;
+                                } else {
+                                    pos = ol.proj.transform([data.lon, data.lat],
+                                        data.projection, viewProjection);
+                                }
+                                label = createOverlay(element, pos);
+                                angular.forEach(map.getOverlays(), function (value, key) {
+                                    map.removeOverlay(value);
+                                });
+                                map.addOverlay(label);
+                            }
+                            map.getTarget().style.cursor = 'pointer';
+                        }
+
+                        if (!found && label) {
+                            actionTaken = true;
+                            label = undefined;
+                            map.getTarget().style.cursor = '';
+                        }
+
+                        if (actionTaken) {
+                            evt.preventDefault();
+                        }
+                    }
+                    
+                    function removeAllOverlays(evt) {
+                        angular.forEach(map.getOverlays(), function (value, key) {
+                            map.removeOverlay(value);
+                        });
+                        evt.preventDefault();
+                    }
+                    
                     if (!isDefined(marker)) {
                         data.projection = properties.projection ? properties.projection :
                             data.projection;
@@ -271,6 +320,12 @@ angular.module('openlayers-directive').directive('olMarker', function($log, $q, 
                         map.getViewport().addEventListener('click', handleTapInteraction);
                         map.getViewport().querySelector('canvas.ol-unselectable').addEventListener(
                             'touchend', handleTapInteraction);
+                    }
+                    
+                    if ((properties.label && properties.label.show === false &&
+                        properties.label.keepOneOverlayVisible)) {
+                        map.getViewport().addEventListener('mousemove', showAtLeastOneOverlay);
+                        map.getViewport().addEventListener('click', removeAllOverlays);
                     }
                 }, true);
             });


### PR DESCRIPTION
Feature to show a marker's overlay until the user enters the mouse in other marker, when the overlay is changed to display the new marker's info. With this new behaviour an overlay is always visible unless the user clicks on a free marker zone of the map, which forces the visible overlay to close itself.
